### PR TITLE
Feat: Adding a flag to skip fetching env variables from etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To run a container with this image or its derivative, you'll need to prepare:
 
 If you're done so, to start a container, you'll need to define these environment variables:
 
-- `USE_ETCD`: Enable fetching environment variables from `etcd` server.
+- `USE_ETCD`: Set this environment variable to enable fetching environment variables from `etcd` server.
 - `ETCD_SERVER`: URL to `etcd` client endpoint, e.g. `http://192.168.0.22:2379`.
 - `ENV_PATH`: Full absolute path to env file, e.g. `/app/.env`.
 - `ENV_PREFIX`: `etcd` key prefix for env variables, e.g. `/com/qeon/www/envs`.
@@ -48,6 +48,7 @@ docker run \
     -d \
     --rm \
     -p 9000:9000 \
+    --env "USE_ETCD=yes" \
     --env "ETCD_SERVER=http://192.168.0.22:2379" \
     --env "ENV_PATH=/app/.env" \
     --env "ENV_PREFIX=/com/qeon/www/envs" \

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ To run a container with this image or its derivative, you'll need to prepare:
 1. Project env's key prefix, and
 1. Project's assumed env file location.
 
-If you're done so, to start a container, you'll need to define 3 environment variables:
+If you're done so, to start a container, you'll need to define these environment variables:
 
-- `ETCD_SERVER`: URL to `etcd` client endpoint, e.g. `http://192.168.0.22:2379`
+- `USE_ETCD`: Enable fetching environment variables from `etcd` server.
+- `ETCD_SERVER`: URL to `etcd` client endpoint, e.g. `http://192.168.0.22:2379`.
 - `ENV_PATH`: Full absolute path to env file, e.g. `/app/.env`.
 - `ENV_PREFIX`: `etcd` key prefix for env variables, e.g. `/com/qeon/www/envs`.
 

--- a/runnables/90-fetch_envs.sh
+++ b/runnables/90-fetch_envs.sh
@@ -3,6 +3,11 @@
 # fetch all required environments and put it to working directory
 # requires ETCD_SERVER, ENV_PATH, ENV_PREFIX
 
+if [ -z "$USE_ETCD" ]; then
+	echo "Skipping getting env data from etcd."
+	exit 0;
+fi
+
 [ -z "$ETCD_SERVER" ] && { >&2 echo "No etcd endpoint specified. Set etcd endpoints with ETCD_SERVER environment variable."; exit 1; };
 [ -z "$ENV_PATH" ] && { >&2 echo "No env file path set. Set env file path with ENV_PATH environment variable."; exit 1; };
 [ -z "$ENV_PREFIX" ] && { >&2 echo "No env prefix set. Set env prefix path with ENV_PREFIX environment variable."; exit 1; };


### PR DESCRIPTION
To accomodate newer projects that's probably using cloud services' secret manager (as a better alternative to `etcd`), we need to add a flag to skip environment variable fetching process.

In previous build, the `90-fetch-envs` routine within `runnables/` will always be run.

This PR adds this new environment variable:

`USE_ETCD=[(empty)|(any)]`

which if not set (or set to empty string), will skip `90-fetch-envs` routine. To run `90-fetch-envs` routine (which is the old default), set this environment variable to anything (except empty string).

By default, this environment variable is not set.