### PR TITLE
Feat: Publish Images to Github Container Registry via Github Actions

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,52 @@
+---
+name: "Build and Publish Images on Release"
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  generator:
+    strategy:
+      fail-fast: true
+      matrix:
+        version:
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Login to Github Container Registry
+        run: |
+          echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
+
+      - name: Build Image
+        env:
+          PHP_VERSION: ${{ matrix.version }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          IMAGE_BASENAME=$(echo "ghcr.io/${{ secrets.GHCR_ACTOR }}/docker-php7.3-fpm" | tr '[A-Z]' '[a-z]')
+          docker build . \
+            --file php_fpm-${PHP_VERSION}/Dockerfile \
+            --label "org.opencontainers.image.source=https://github.com/${{ secrets.GHCR_ACTOR }}/docker-php7.3-fpm" \
+            --label "org.opencontainers.image.url=https://github.com/${{ secrets.GHCR_ACTOR }}/docker-php7.3-fpm" \
+            --label "org.opencontainers.image.created=$(date -Iseconds)" \
+            --label "org.opencontainers.image.version=${RELEASE}" \
+            --tag ${IMAGE_BASENAME}:php-${PHP_VERSION} \
+            --tag ${IMAGE_BASENAME}:${RELEASE}_php-${PHP_VERSION}
+
+      - name: Push new Image to Github Container Registry
+        env:
+          PHP_VERSION: ${{ matrix.version }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          IMAGE_BASENAME=$(echo "ghcr.io/${{ secrets.GHCR_ACTOR }}/docker-php7.3-fpm" | tr '[A-Z]' '[a-z]')
+          docker push ${IMAGE_BASENAME}:php-${PHP_VERSION}
+          docker push ${IMAGE_BASENAME}:${RELEASE}_php-${PHP_VERSION}

--- a/.github/workflows/manual-build-images.yaml
+++ b/.github/workflows/manual-build-images.yaml
@@ -1,0 +1,50 @@
+---
+name: "Manual Build and Publish Images"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generator:
+    strategy:
+      fail-fast: true
+      matrix:
+        version:
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Login to Github Container Registry
+        run: |
+          echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
+
+      - name: Build Image
+        env:
+          PHP_VERSION: ${{ matrix.version }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          IMAGE_BASENAME=$(echo "ghcr.io/${{ secrets.GHCR_ACTOR }}/docker-php7.3-fpm" | tr '[A-Z]' '[a-z]')
+          docker build . \
+            --file php_fpm-${PHP_VERSION}/Dockerfile \
+            --label "org.opencontainers.image.source=https://github.com/${{ secrets.GHCR_ACTOR }}/docker-php7.3-fpm" \
+            --label "org.opencontainers.image.url=https://github.com/${{ secrets.GHCR_ACTOR }}/docker-php7.3-fpm" \
+            --label "org.opencontainers.image.created=$(date -Iseconds)" \
+            --label "org.opencontainers.image.version=${RELEASE}" \
+            --tag ${IMAGE_BASENAME}:php-${PHP_VERSION} \
+            --tag ${IMAGE_BASENAME}:${RELEASE}_php-${PHP_VERSION}
+
+      - name: Push new Image to Github Container Registry
+        env:
+          PHP_VERSION: ${{ matrix.version }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          IMAGE_BASENAME=$(echo "ghcr.io/${{ secrets.GHCR_ACTOR }}/docker-php7.3-fpm" | tr '[A-Z]' '[a-z]')
+          docker push ${IMAGE_BASENAME}:php-${PHP_VERSION}
+          docker push ${IMAGE_BASENAME}:${RELEASE}_php-${PHP_VERSION}


### PR DESCRIPTION
Added automation on build and publishing images to Github Container Registry (GHCR) via Github Actions.

---

To build and publish images to GHCR, you'll need to define this Github Actions secrets:

- Authentication secrets
  These secrets are used to authenticate against GHCR.
    - `GHCR_USERNAME`: Github username to be used to authenticate to GHCR.
    - `GHCR_TOKEN`: Github [Personal Access Token][1] (PAT) from given Github username. This PAT should have `repo`, `write:packages`. and `read:packages` access.
    
- Tagging information
    - `GHCR_ACTOR`: Github account/organization to store images at.

After defining these secrets, you'll have two ways to generate image:
1. Using releases.
    Go to [Releases][3] page, select "_Draft a new release_".

    If you have created a release tag, select the tag from "_Choose a tag_" drop down. If you haven't created a release tag, click on "_Choose a tag_" drop down, type a new tag name, and click on "_Create a new tag: \<tag name\> on publish_".
    
    Add release informations, e.g. PR references, Issue references, changelogs, etc; then click on "_Publish release_". Github Actions will automatically run "_Build and Publish Images on Release_" workflow when the release is published.

2. Manual build and publish.
    Go to [Actions][2] page, select "_Manual Build and Publish Images_" workflow, then click on "_Run workflow_".

    On "_Use workflow from_", select "_Branch: main_". Click on "_Run workflow_" to start manually build and publish images.

[1]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
[2]: https://github.com/Qeon-Digital-House/docker-php7.3-fpm/actions
[3]: https://github.com/Qeon-Digital-House/docker-php7.3-fpm/releases