### PR TITLE
Fix: Failed Building Image with PHP-FPM 7.3

### DIFF
--- a/php_fpm-7.3/Dockerfile
+++ b/php_fpm-7.3/Dockerfile
@@ -5,14 +5,15 @@ WORKDIR /var/www/html
 COPY docker-php-entrypoint get-composer.sh /usr/local/bin/
 COPY runnables/*.sh /usr/local/runnables/
 
-RUN apt-get update \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/buster-backports.list \
+    && apt-get update \
     && apt-get -y dist-upgrade \
     && apt-get -y install etcd-client vim curl unzip gnupg2 software-properties-common \
                           zlib1g-dev libzip-dev libicu-dev libbz2-dev libpng-dev \
-                          libwebp-dev libjpeg-dev libfreetype-dev libgmp-dev \
+                          libwebp-dev libjpeg-dev libfreetype6-dev libgmp-dev \
                           libxslt1-dev liblzf-dev libzstd-dev mariadb-client \
     && apt-get -y autoremove \
-    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
+    && docker-php-ext-configure gd --with-webp-dir --with-jpeg-dir --with-freetype-dir \
     && docker-php-ext-install bcmath calendar bz2 exif \
                               gd gettext gmp intl pcntl \
                               pdo_mysql shmop sockets \


### PR DESCRIPTION
- Added `buster-backports` source to image.
- `buster` uses `libfreetype6-dev` instead of `libfreetype-dev`.
- `gd` extension changed in PHP 7.4. Reverting `./configure` options using old `-dir` suffix instead of newer one. See [Migration to pkg-config][1]

[1]: https://www.php.net/manual/en/migration74.other-changes.php#migration74.other-changes.pkg-config