### PR TITLE
Fix: Publishing Image Failed with "denied: permission_denied: create_package" Error

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -18,6 +18,10 @@ jobs:
           - "8.1"
 
     runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/manual-build-images.yaml
+++ b/.github/workflows/manual-build-images.yaml
@@ -16,6 +16,10 @@ jobs:
           - "8.1"
 
     runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
- Added `permissions.packages: write` to allow write permission to Github Packages.