### PR TITLE
Fix: Container run should crash on runnables failure

### DIFF
--- a/docker-php-entrypoint
+++ b/docker-php-entrypoint
@@ -4,6 +4,11 @@ set -e
 # run all runnables in /usr/local/runnables before executing our entrypoint.
 for runnable in /usr/local/runnables/*.sh; do
     /bin/bash $runnable
+
+    if [ "$?" -ne "0" ]; then
+        >&2 echo "[!] FATAL: Some of the required scripts failed to run."
+        exit 1
+    fi
 done
 
 # first arg is `-f` or `--some-option`

--- a/runnables/90-fetch_envs.sh
+++ b/runnables/90-fetch_envs.sh
@@ -8,16 +8,16 @@ if [ -z "$USE_ETCD" ]; then
 	exit 0;
 fi
 
-[ -z "$ETCD_SERVER" ] && { >&2 echo "No etcd endpoint specified. Set etcd endpoints with ETCD_SERVER environment variable."; exit 1; };
-[ -z "$ENV_PATH" ] && { >&2 echo "No env file path set. Set env file path with ENV_PATH environment variable."; exit 1; };
-[ -z "$ENV_PREFIX" ] && { >&2 echo "No env prefix set. Set env prefix path with ENV_PREFIX environment variable."; exit 1; };
+[ -z "$ETCD_SERVER" ] && { >&2 echo "[!] FATAL: No etcd endpoint specified. Set etcd endpoints with ETCD_SERVER environment variable."; exit 1; };
+[ -z "$ENV_PATH" ] && { >&2 echo "[!] FATAL: No env file path set. Set env file path with ENV_PATH environment variable."; exit 1; };
+[ -z "$ENV_PREFIX" ] && { >&2 echo "[!] FATAL: No env prefix set. Set env prefix path with ENV_PREFIX environment variable."; exit 1; };
 
 # check if we have any etcd data to avoid bad env file.
 ENV_SIZE=$(ETCDCTL_API=3 etcdctl --endpoints "$ETCD_SERVER" get --prefix "$ENV_PREFIX" | wc -l)
 
 if [ "$ENV_SIZE" -eq "0" ]; then
-    >&2 echo "Can't get env data from etcd. Skipping."
-    exit 1
+    >&2 echo "[!] FATAL: Can't get env data from etcd. Skipping."
+    exit 1;
 fi
 
 # really fetch the entries from etcd.
@@ -32,3 +32,5 @@ ETCDCTL_API=3 \
 		KEY_PARSE=$(echo -ne "$KEY"); \
 		VALUE_PARSE=$(echo -ne "$VALUE"); \
 		echo ${KEY_PARSE##*/}="${VALUE_PARSE}"; done > "$ENV_PATH"
+
+exit 0


### PR DESCRIPTION
- Container run now crash on runnables failure.
    We crash container on runnable failure to allow user to check if any error present on runtime, and to adjust it preventing the same problem in the future.
- Runnables script now should end with non-zero `exit` on failure. This will propagate to `docker-php-entrypoint` to crash the container on runtime.