### PR TITLE
Fix: Automated build problems and unloaded PHP module

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -43,6 +43,7 @@ jobs:
             --label "org.opencontainers.image.url=https://github.com/${{ secrets.GHCR_ACTOR }}/docker-php7.3-fpm" \
             --label "org.opencontainers.image.created=$(date -Iseconds)" \
             --label "org.opencontainers.image.version=${RELEASE}" \
+            --tag base-swoole:php-${PHP_VERSION} \
             --tag ${IMAGE_BASENAME}:php-${PHP_VERSION} \
             --tag ${IMAGE_BASENAME}:${RELEASE}_php-${PHP_VERSION}
 

--- a/php_fpm-7.3/Dockerfile
+++ b/php_fpm-7.3/Dockerfile
@@ -31,7 +31,7 @@ RUN docker-php-ext-enable bcmath calendar bz2 exif \
                           gd gettext gmp intl pcntl \
                           pdo_mysql shmop sockets pdo_pgsql \
                           sysvmsg sysvsem sysvshm \
-                          xsl opcache zip igbinary redis \
+                          xsl opcache zip igbinary msgpack redis \
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && chmod 755 /usr/local/bin/get-composer.sh /usr/local/bin/docker-php-entrypoint \
     && /usr/local/bin/get-composer.sh \

--- a/php_fpm-7.4/Dockerfile
+++ b/php_fpm-7.4/Dockerfile
@@ -30,7 +30,7 @@ RUN docker-php-ext-enable bcmath calendar bz2 exif \
                           gd gettext gmp intl pcntl \
                           pdo_mysql shmop sockets pdo_pgsql \
                           sysvmsg sysvsem sysvshm \
-                          xsl opcache zip igbinary redis \
+                          xsl opcache zip igbinary msgpack redis \
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && chmod 755 /usr/local/bin/get-composer.sh /usr/local/bin/docker-php-entrypoint \
     && /usr/local/bin/get-composer.sh \

--- a/php_fpm-8.0/Dockerfile
+++ b/php_fpm-8.0/Dockerfile
@@ -31,7 +31,7 @@ RUN docker-php-ext-enable bcmath calendar bz2 exif \
                           gd gettext gmp intl pcntl \
                           pdo_mysql shmop sockets pdo_pgsql \
                           sysvmsg sysvsem sysvshm \
-                          xsl opcache zip igbinary redis \
+                          xsl opcache zip igbinary msgpack redis \
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && chmod 755 /usr/local/bin/get-composer.sh /usr/local/bin/docker-php-entrypoint \
     && /usr/local/bin/get-composer.sh \

--- a/php_fpm-8.1/Dockerfile
+++ b/php_fpm-8.1/Dockerfile
@@ -31,7 +31,7 @@ RUN docker-php-ext-enable bcmath calendar bz2 exif \
                           gd gettext gmp intl pcntl \
                           pdo_mysql shmop sockets pdo_pgsql \
                           sysvmsg sysvsem sysvshm \
-                          xsl opcache zip igbinary redis \
+                          xsl opcache zip igbinary msgpack redis \
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && chmod 755 /usr/local/bin/get-composer.sh /usr/local/bin/docker-php-entrypoint \
     && /usr/local/bin/get-composer.sh \


### PR DESCRIPTION
- Automated build now also tag base image to be used in Swoole image build.
- Now `msgpack` module is loaded before `redis` module loaded.