### PR TITLE
Feature: Cleanup Image to Save Space

### DIFF
--- a/php_fpm-7.3/Dockerfile
+++ b/php_fpm-7.3/Dockerfile
@@ -43,4 +43,6 @@ RUN docker-php-ext-enable bcmath calendar bz2 exif \
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && chmod 755 /usr/local/bin/get-composer.sh /usr/local/bin/docker-php-entrypoint \
     && /usr/local/bin/get-composer.sh \
-    && rm -fr /usr/local/bin/get-composer.sh
+    && rm -fr /usr/local/bin/get-composer.sh \
+    && rm -fr /tmp/pear \
+    && rm -fr /var/cache/apt

--- a/php_fpm-7.4/Dockerfile
+++ b/php_fpm-7.4/Dockerfile
@@ -42,4 +42,6 @@ RUN docker-php-ext-enable bcmath calendar bz2 exif \
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && chmod 755 /usr/local/bin/get-composer.sh /usr/local/bin/docker-php-entrypoint \
     && /usr/local/bin/get-composer.sh \
-    && rm -fr /usr/local/bin/get-composer.sh
+    && rm -fr /usr/local/bin/get-composer.sh \
+    && rm -fr /tmp/pear \
+    && rm -fr /var/cache/apt

--- a/php_fpm-8.0/Dockerfile
+++ b/php_fpm-8.0/Dockerfile
@@ -43,4 +43,6 @@ RUN docker-php-ext-enable bcmath calendar bz2 exif \
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && chmod 755 /usr/local/bin/get-composer.sh /usr/local/bin/docker-php-entrypoint \
     && /usr/local/bin/get-composer.sh \
-    && rm -fr /usr/local/bin/get-composer.sh
+    && rm -fr /usr/local/bin/get-composer.sh \
+    && rm -fr /tmp/pear \
+    && rm -fr /var/cache/apt

--- a/php_fpm-8.0/Dockerfile.swoole
+++ b/php_fpm-8.0/Dockerfile.swoole
@@ -10,4 +10,6 @@ RUN apt-get update \
                                         enable-mysqlnd='yes' enable-swoole-curl='yes' enable-swoole-pgsql='yes' \
                                         enable-openssl='yes'" \
        swoole \
-    && docker-php-ext-enable swoole
+    && docker-php-ext-enable swoole \
+    && rm -fr /tmp/pear \
+    && rm -fr /var/cache/apt

--- a/php_fpm-8.1/Dockerfile
+++ b/php_fpm-8.1/Dockerfile
@@ -43,4 +43,6 @@ RUN docker-php-ext-enable bcmath calendar bz2 exif \
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && chmod 755 /usr/local/bin/get-composer.sh /usr/local/bin/docker-php-entrypoint \
     && /usr/local/bin/get-composer.sh \
-    && rm -fr /usr/local/bin/get-composer.sh
+    && rm -fr /usr/local/bin/get-composer.sh \
+    && rm -fr /tmp/pear \
+    && rm -fr /var/cache/apt

--- a/php_fpm-8.1/Dockerfile.swoole
+++ b/php_fpm-8.1/Dockerfile.swoole
@@ -10,4 +10,6 @@ RUN apt-get update \
                                         enable-mysqlnd='yes' enable-swoole-curl='yes' enable-swoole-pgsql='yes' \
                                         enable-openssl='yes'" \
        swoole \
-    && docker-php-ext-enable swoole
+    && docker-php-ext-enable swoole \
+    && rm -fr /tmp/pear \
+    && rm -fr /var/cache/apt


### PR DESCRIPTION
remove `/tmp/pear` and `/var/cache/apt` at the end of image build process.