### PR TITLE
Fix: mongodb and laravel-mongodb composer library requires previous mongodb extension version

### DIFF
--- a/php_fpm-8.1/Dockerfile
+++ b/php_fpm-8.1/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
                                         with-mongodb-sasl='auto' with-mongodb-ssl='auto' \
                                         enable-mongodb-crypto-system-profile='no' enable-system-ciphers='no' \
                                         with-mongodb-utf8proc='bundled'" \
-        mongodb \
+        mongodb-1.21.1 \
     && pecl install --configureoptions "with-rdkafka='yes'" rdkafka
 
 RUN docker-php-ext-enable bcmath calendar bz2 exif \


### PR DESCRIPTION
- `mongodb/mongodb` requires `^1.17.0`
- `mongodb/laravel-mongodb` requires `^1.15.0`
- Locks mongodb extension to v1.21.1